### PR TITLE
Update process to resolve gulp executable.  

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ var Promise = require('bluebird');
  * Looks up what gulp bin should be used.
  * In order of priority:
  * 	1. Global gulp
- * 	2. Gulp local to where script is ran.
- * 	3. Our own gulp bin.
+ * 	2. Gulp module loaded via require.
+ * If no gulp module is found throws an error.
  */
 function getGulpBin() {
   var globalGulp = '/usr/local/bin/gulp';
@@ -21,19 +21,11 @@ function getGulpBin() {
     return globalGulp;
   }
 
-  var localGulpPath = 'node_modules/gulp/bin/gulp.js';
+  var localGulpModule = require.resolve('gulp');
 
-  var localGulp = path.join(process.cwd(), localGulpPath);
+  var localGulpBin = path.join(path.dirname(localGulpModule), 'bin/gulp.js');
 
-  if (fs.existsSync(localGulp)) {
-    return localGulp;
-  }
-
-  var selfGulp = path.join(__dirname, localGulpPath);
-
-  if (fs.existsSync(selfGulp)) {
-    return selfGulp;
-  }
+  return localGulpBin;
 }
 
 var TASK = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-slurpee",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Run the same gulp task from multiple gulpfile's concurrently.",
   "repository": "https://github.com/chartbeat-labs/gulp-slurpee.git",
   "author": "Harry Wolff <harry@chartbeat.com>",


### PR DESCRIPTION
Use the built-in require.resolve to find the closest gulp module instead of just searching the file system itself.
